### PR TITLE
FIXING PHASE PRE GAD-005 GATE 001

### DIFF
--- a/.github/workflows/test-google-api.yml
+++ b/.github/workflows/test-google-api.yml
@@ -1,12 +1,14 @@
 name: Test Google Search API
 
 on:
-  push:
-    branches:
-      - claude/**
-      - main
-      - develop
-  workflow_dispatch:
+  workflow_dispatch:  # Manual trigger only - real API calls disabled in CI/CD
+  # Disabled auto-trigger to prevent 429 rate limit errors
+  # See: docs/reports/CRITICAL_REAL_API_CALLS_IN_TESTS.md
+  # push:
+  #   branches:
+  #     - claude/**
+  #     - main
+  #     - develop
 
 jobs:
   test-research-tools:


### PR DESCRIPTION
This pull request updates the workflow configuration for testing the Google Search API to prevent accidental real API calls during automated CI/CD runs. The workflow can now only be triggered manually, with clear documentation added to explain the change.

Workflow configuration changes:

* Disabled automatic triggering of the `.github/workflows/test-google-api.yml` workflow on pushes to key branches, so it can only be run manually. This helps prevent hitting Google API rate limits due to real API calls in CI/CD.
* Added comments referencing documentation (`docs/reports/CRITICAL_REAL_API_CALLS_IN_TESTS.md`) to clarify the reason for disabling auto-triggering and to guide future maintainers.